### PR TITLE
Update Eigen download link

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.DS_Store
 build*
+external/
 *user
 
 memsurfer.egg-info/

--- a/install_deps.sh
+++ b/install_deps.sh
@@ -100,7 +100,7 @@ if [ "$INSTALL_EIGEN" = true ] ; then
     VERSION='3.3.7'
     NAME='Eigen-'$VERSION
     FILE=$VERSION.tar.bz2
-    URL=http://bitbucket.org/eigen/eigen/get/$FILE
+    URL=https://gitlab.com/libeigen/eigen/-/archive/$VERSION/$FILE
     TEST=$PATH_Ext/include/eigen3
 
     _test $TEST


### PR DESCRIPTION
Bitbucket no longer hosts Eigen and the project has been moved to GitLab. This PR updates the link in `install_deps.sh`