### PR TITLE
fix in periodic delaunay

### DIFF
--- a/memsurfer/src/TriMesh.cpp
+++ b/memsurfer/src/TriMesh.cpp
@@ -426,6 +426,7 @@ bool TriMesh::wrap_vertices(uint8_t dim) {
     const Vertex boxw = this->mBox1 - this->mBox0;
 
     const size_t nverts = mVertices.size();
+    std::cout << " wrapping " << nverts << " vertices!\n";
     for(size_t i=0; i<nverts; i++) {
     for(uint8_t d=0; d<dim; d++) {
         TypeFunction &x = mVertices[i][d];
@@ -461,24 +462,22 @@ void TriMesh::trim_periodicDelaunay(bool verbose) {
 
     for(size_t i = 0; i < ndfaces; i++) {
 
-        const std::vector<periodicVertex> &dface = this->mDelaunayFaces[i];
+        const std::vector<PeriodicVertex> &dface = this->mDelaunayFaces[i];
 
         Face face, tface;
         uint8_t num_orig_verts = 0;
 
         for(uint8_t d = 0; d < 3; d++) {
 
-            const periodicVertex &pvertex = dface[d];
+            const PeriodicVertex &pvertex = dface[d];
 
-            const TypeIndex orig_vid = std::get<0>(pvertex);
-            const int offx = std::get<1>(pvertex);
-            const int offy = std::get<2>(pvertex);
+            const TypeIndex orig_vid = pvertex.origVidx;
 
             face[d] = orig_vid;
             tface[d] = orig_vid;
 
             // is an original vertex
-            if (offx == 0 && offy == 0) {
+            if (pvertex.is_original()) {
                 num_orig_verts++;
                 continue;
             }
@@ -491,6 +490,9 @@ void TriMesh::trim_periodicDelaunay(bool verbose) {
                 ndupid = noverts + std::distance(mDuplicateVertex_periodic.begin(), iter);
             }
             else {
+                const int offx = pvertex.offsetx;
+                const int offy = pvertex.offsety;
+
                 // otherwise, let's duplicate
                 Vertex dv (mVertices[orig_vid]);
                 dv[0] += (offx == 0) ? 0.0 : float(offx) *boxw[0];

--- a/memsurfer/src/TriMesh.cpp
+++ b/memsurfer/src/TriMesh.cpp
@@ -426,7 +426,6 @@ bool TriMesh::wrap_vertices(uint8_t dim) {
     const Vertex boxw = this->mBox1 - this->mBox0;
 
     const size_t nverts = mVertices.size();
-    std::cout << " wrapping " << nverts << " vertices!\n";
     for(size_t i=0; i<nverts; i++) {
     for(uint8_t d=0; d<dim; d++) {
         TypeFunction &x = mVertices[i][d];

--- a/memsurfer/src/TriMesh.hpp
+++ b/memsurfer/src/TriMesh.hpp
@@ -25,6 +25,36 @@ For details, see https://github.com/LLNL/MemSurfer.
 class DensityKernel;        // kernel for density estimation
 class DistanceKernel;
 
+
+//! A periodic vertex is stored as an offset (-1,0,1) with respect to the original vertex
+struct PeriodicVertex {
+    TypeIndex origVidx;
+    int8_t offsetx, offsety;
+
+    PeriodicVertex () :
+        origVidx(0), offsetx(0), offsety(0) {}
+
+    PeriodicVertex (const TypeIndex v, const int8_t ox, const int8_t oy)
+        : origVidx(v), offsetx(ox), offsety(oy) {}
+
+    inline bool operator==(const PeriodicVertex &p) const {
+        return origVidx == p.origVidx && offsetx == p.offsetx && offsety == p.offsety;
+    }
+    inline bool is_original() const {
+        return offsetx == 0 and offsety == 0;
+    }
+
+    /*inline bool is_sameOriginal(const PeriodicVertex &p) const {
+        return origVidx == p.origVidx;
+    }*/
+};
+
+inline
+std::ostream&
+operator<<(std::ostream &os, const PeriodicVertex &p) {
+    return os << "("<<p.origVidx<<" : ["<<int(p.offsetx)<<","<<int(p.offsety)<<"])";
+}
+
 /// ---------------------------------------------------------------------------------------
 //!
 //! \brief This class provides functionality to operate upon a Triangular Mesh
@@ -71,14 +101,11 @@ private:
     bool bbox_valid;
     Vertex mBox0, mBox1;
 
-    //! On addition to the *actual* vertices and faces (i.e., inside the given domain),
+    //! In addition to the *actual* vertices and faces (i.e., inside the given domain),
     //! we need to store extra information
 
-    //! A periodic vertex is stored as an offset (-1,0,1) with respect to the original vertex
-    using periodicVertex = typename std::tuple<TypeIndex, int, int>;
-
     //! Delaunay Faces
-    std::vector<std::vector<periodicVertex> > mDelaunayFaces;
+    std::vector<std::vector<PeriodicVertex> > mDelaunayFaces;
 
     //! The faces that go across the domain (contain original points)
     std::vector<Face> mPeriodicFaces;
@@ -87,7 +114,7 @@ private:
     std::vector<Face> mTrimmedFaces;
 
     //! The duplicate vertices that map to the original
-    std::vector<periodicVertex> mDuplicateVertex_periodic;
+    std::vector<PeriodicVertex> mDuplicateVertex_periodic;
 
     //! The vertices to support duplicate faces
     std::vector<Vertex> mDuplicateVerts;
@@ -181,7 +208,7 @@ private:
     bool set_dimensionality(uint8_t _);
 
     //! sort vertices spatially (using cgal)
-    void sort_vertices(std::vector<Point_with_idx> &svertices) const;
+    std::vector<Point_with_idx> sort_vertices() const;
 
     //! wrap vertices in xy (dim = 2) or in xyz (dim = 3)
     bool wrap_vertices(uint8_t dim = 2);
@@ -308,7 +335,7 @@ public:
         const size_t ndups = mDuplicateVertex_periodic.size();
         std::vector<TypeIndexI> dids (ndups);
         for(size_t i = 0; i < ndups; i++)
-            dids[i] = std::get<0>(mDuplicateVertex_periodic[i]);
+            dids[i] = mDuplicateVertex_periodic[i].origVidx;
         return dids;
     }
 

--- a/memsurfer/src/TriMesh.hpp
+++ b/memsurfer/src/TriMesh.hpp
@@ -43,10 +43,6 @@ struct PeriodicVertex {
     inline bool is_original() const {
         return offsetx == 0 and offsety == 0;
     }
-
-    /*inline bool is_sameOriginal(const PeriodicVertex &p) const {
-        return origVidx == p.origVidx;
-    }*/
 };
 
 inline

--- a/memsurfer/src/TriMesh_cgal.cpp
+++ b/memsurfer/src/TriMesh_cgal.cpp
@@ -229,7 +229,7 @@ std::vector<TypeIndexI> TriMesh::periodicDelaunay(bool verbose) {
              delFace[0] == delFace[2] ||
              delFace[1] == delFace[2]) {
             // this should not happen after the fix on Apr 18, 2022
-            std::cerr << "Warning: found a zero edge: " << total_nfaces << " = [[" << delFace[0] << "," << delFace[1] << "," << delFace[2] << "]]\n";
+            std::cerr << "> Warning: found a zero edge: " << total_nfaces << " = [[" << delFace[0] << "," << delFace[1] << "," << delFace[2] << "]]\n"
             continue;
         }
 
@@ -237,7 +237,7 @@ std::vector<TypeIndexI> TriMesh::periodicDelaunay(bool verbose) {
              delFace[0].origVidx == delFace[2].origVidx ||
              delFace[1].origVidx == delFace[2].origVidx ) {
             // this should not happen after the fix on Apr 18, 2022
-            std::cout << "Warning: duplicated original: " << total_nfaces << " = [[" << delFace[0] << "," << delFace[1] << "," << delFace[2] << "]]\n";
+            std::cout << "> Warning: duplicated original: " << total_nfaces << " = [[" << delFace[0] << "," << delFace[1] << "," << delFace[2] << "]]\n";
             continue;
         }
 

--- a/memsurfer/src/TriMesh_cgal.cpp
+++ b/memsurfer/src/TriMesh_cgal.cpp
@@ -13,7 +13,7 @@ For details, see https://github.com/LLNL/MemSurfer.
 /// ----------------------------------------------------------------------------
 
 #include <map>
-#include<string>
+#include <string>
 #include <sstream>
 #include <stdexcept>
 #include <algorithm>
@@ -66,26 +66,31 @@ TriMesh::TriMesh(const Polyhedron &P) {
 
 #ifdef CGAL_AVAILABLE
 #include <CGAL/spatial_sort.h>
+#include <CGAL/Spatial_sort_traits_adapter_2.h>
 #include <CGAL/Spatial_sort_traits_adapter_3.h>
 #endif
 
-void TriMesh::sort_vertices(std::vector<Point_with_idx> &svertices) const {
+// create a spatially sorted list of points
+std::vector<Point_with_idx>
+TriMesh::sort_vertices() const {
+
+    std::vector<Point_with_idx> svertices;
 
 #ifndef CGAL_AVAILABLE
     std::cerr << " ERROR: " << this->tag() <<"::sort_vertices - CGAL not available! cannot sort vertices!\n";s
 #else
-    typedef CGAL::Spatial_sort_traits_adapter_3<Kernel, CGAL::First_of_pair_property_map<Point_with_idx>> Sort_traits;
+    typedef CGAL::Spatial_sort_traits_adapter_2<Kernel, CGAL::First_of_pair_property_map<Point_with_idx>> Sort_traits;
 
-    // create a spatially sorted list of points
-    svertices.clear();
-    svertices.resize(mVertices.size());
-    for(size_t i = 0; i < mVertices.size(); i++) {
-        svertices[i] = std::make_pair(Point3(mVertices[i][0], mVertices[i][1], mVertices[i][2]), i);
+    svertices.reserve(mVertices.size());
+    size_t i = 0;
+    for(auto viter = mVertices.begin(); viter != mVertices.end(); ++i, ++viter) {
+        svertices.emplace_back(std::make_pair(Point2((*viter)[0], (*viter)[1]), i));
     }
 
     Sort_traits traits;
     CGAL::spatial_sort(svertices.begin(), svertices.end(), traits);
 #endif
+    return svertices;
 }
 
 //! -----------------------------------------------------------------------------
@@ -133,17 +138,12 @@ std::vector<TypeIndexI> TriMesh::delaunay(bool verbose) {
 
     //CGAL::Random::Random(0);
 
-    // sort the vertices
-    std::vector<Point_with_idx> cgalVertices;
-    this->sort_vertices(cgalVertices);
+    // sort spatially
+    std::vector<Point_with_idx> cgalVertices = this->sort_vertices();
 
     // compute delaunay
     Delaunay dt;
-    for(size_t i = 0; i < cgalVertices.size(); i++) {
-        Kernel::Point_3 &p = cgalVertices[i].first;     // although a 3D point, the data inside is 2D!
-        Delaunay::Vertex_handle vh = dt.insert(Delaunay::Point(p[0],p[1]));
-        vh->info() = cgalVertices[i].second;
-    }
+    dt.insert(cgalVertices.begin(), cgalVertices.end());
 
     mFaces.clear();
     for(auto iter = dt.finite_faces_begin(); iter != dt.finite_faces_end(); ++iter) {
@@ -183,28 +183,24 @@ std::vector<TypeIndexI> TriMesh::periodicDelaunay(bool verbose) {
         fflush(stdout);
     }
 
+    // wrap into the box and sort spatially
     this->wrap_vertices();
-
-    // sort the vertices
-    std::vector<Point_with_idx> cgalVertices;
-    this->sort_vertices(cgalVertices);
+    std::vector<Point_with_idx> cgalVertices = this->sort_vertices();
 
     // compute delaunay
     Delaunay::Iso_rectangle pbox(mBox0[0], mBox0[1], mBox1[0], mBox1[1]);
     Delaunay dt (pbox);
-
-    for(size_t i = 0; i < cgalVertices.size(); i++) {
-        Kernel::Point_3 &p = cgalVertices[i].first;
-        Delaunay::Vertex_handle vh = dt.insert(Delaunay::Point(p[0],p[1]));
-        vh->info() = cgalVertices[i].second;
-    }
+    dt.insert(cgalVertices.begin(), cgalVertices.end());
 
     // store the raw delaunay faces
     this->mDelaunayFaces.clear();
-    std::vector<periodicVertex> delFace (3);
+    std::vector<PeriodicVertex> delFace (3);
 
+    // convert to 3x3 subgrid to handle periodicity
+    // for each delaunay face, see if it has "duplicated" vertices
     dt.convert_to_9_sheeted_covering();
-    for(auto iter = dt.finite_faces_begin(); iter != dt.finite_faces_end(); ++iter) {
+    size_t total_nfaces = 0;
+    for(auto iter = dt.finite_faces_begin(); iter != dt.finite_faces_end(); ++total_nfaces, ++iter) {
 
         // get the type of face (number of original vertex in the face)
         uint8_t num_orig_verts = 0;
@@ -213,21 +209,43 @@ std::vector<TypeIndexI> TriMesh::periodicDelaunay(bool verbose) {
             const Delaunay::Vertex_handle &vh = iter->vertex(vid);
             const Delaunay::Offset &off = dt.periodic_point(vh).second;
 
-            const int offx = off[0] == 2 ? -1 : int(off[0]);
-            const int offy = off[1] == 2 ? -1 : int(off[1]);
+            const int8_t offx = off[0] == 2 ? -1 : int8_t(off[0]);
+            const int8_t offy = off[1] == 2 ? -1 : int8_t(off[1]);
 
-            delFace[vid] = periodicVertex(TypeIndex(vh->info()), offx, offy);
-            if (offx == 0 && offy == 0)
+            delFace[vid] = PeriodicVertex(TypeIndex(vh->info()), offx, offy);
+            if (delFace[vid].is_original())
                 num_orig_verts++;
         }
 
         // ignore the ones that are completely outside
-        if (num_orig_verts > 0) {
-            this->mDelaunayFaces.push_back(delFace);
+        if (num_orig_verts == 0) {
+            continue;
         }
+
+        //std::cout << total_nfaces << " = [[" << delFace[0] << "," << delFace[1] << "," << delFace[2] << "]]\n";
+
+        // if any two verts are the same (not sure why cgal returns that)
+        if ( delFace[0] == delFace[1] ||
+             delFace[0] == delFace[2] ||
+             delFace[1] == delFace[2]) {
+            // this should not happen after the fix on Apr 18, 2022
+            std::cerr << "Warning: found a zero edge: " << total_nfaces << " = [[" << delFace[0] << "," << delFace[1] << "," << delFace[2] << "]]\n";
+            continue;
+        }
+
+        if ( delFace[0].origVidx == delFace[1].origVidx ||
+             delFace[0].origVidx == delFace[2].origVidx ||
+             delFace[1].origVidx == delFace[2].origVidx ) {
+            // this should not happen after the fix on Apr 18, 2022
+            std::cout << "Warning: duplicated original: " << total_nfaces << " = [[" << delFace[0] << "," << delFace[1] << "," << delFace[2] << "]]\n";
+            continue;
+        }
+
+        // finally, we will include this in our triangulation!
+        this->mDelaunayFaces.push_back(delFace);
     }
     if (verbose){
-        std::cout << " Done! created " << mDelaunayFaces.size() << " triangles!\n";
+        std::cout << " Done! created " << mDelaunayFaces.size() << " triangles (out of " << total_nfaces << " periodic ones)!\n";
     }
     trim_periodicDelaunay(verbose);
     return get_faces();

--- a/memsurfer/src/Types.hpp
+++ b/memsurfer/src/Types.hpp
@@ -53,7 +53,8 @@ typedef Kernel::Point_2     Point2;
 typedef Kernel::Point_3     Point3;
 typedef Kernel::Vector_3    Vector3;
 typedef Kernel::Triangle_3  Triangle3;
-typedef std::pair<Point3, size_t> Point_with_idx;
+typedef std::pair<Point2, size_t> Point_with_idx;
+//typedef std::pair<Point3, size_t> Point_with_idx;
 typedef std::pair<Point3, Vector3> Point_with_normal;
 typedef CGAL::Polyhedron_3<Kernel> Polyhedron;
 


### PR DESCRIPTION
bugfix in delauny computation where vertex ids were not being propagated correctly as `vertexhandler->info()`. redid the insertion into `delaunay` using directly a vector of pairs.