### PR TITLE
Updates on setup.py and sub-module definition

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "pypoisson"]
 	path = pypoisson
-	url = git@github.com:mmolero/pypoisson.git
+	url = https://github.com/mmolero/pypoisson.git

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -100,6 +100,12 @@ $ export LD_LIBRARY_PATH=$MEM_HOME/external/lib:$MEM_HOME/external/lib64:$LD_LIB
 $ export DYLD_LIBRARY_PATH=$MEM_HOME/external/lib:$MEM_HOME/external/lib64:$DYLD_LIBRARY_PATH
 ```
 
+##### 1c. Eigen, Boost, and CGAL (conda)
+```
+export MEM_HOME=$your_installation_path
+create -p $MEM_HOME cgal=4.13.0 eigen cython swig cmake numpy gcc_linux-64=7 gxx cython libxcrypt scipy
+```
+
 #### 2. MemSurfer
 
 Once the dependencies have been installed, `MemSurfer` can be installed
@@ -118,6 +124,18 @@ paths.
 $ cd $MEM_HOME
 $ CC=`which gcc` CXX=`which g++` LDCXXSHARED="`which g++` -bundle -undefined dynamic_lookup" \
   python setup.py install
+```
+
+##### 2a. MemSurfer installation within preset conda environment
+
+```
+export CPATH=$MEM_HOME/include
+export CGAL_ROOT=$MEM_HOME
+export EIGEN_ROOT=$MEM_HOME
+export BOOST_ROOT=$MEM_HOME
+git clone https://github.com/gefei-qian-nih/MemSurfer.git
+cd MemSurfer
+CC=`which gcc` CXX=`which g++` LDCXXSHARED="`which g++` -bundle -undefined dynamic_lookup"   python -m pip  install .
 ```
 
 ### Trobubleshooting and Known Issues

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -133,7 +133,8 @@ export CPATH=$MEM_HOME/include
 export CGAL_ROOT=$MEM_HOME
 export EIGEN_ROOT=$MEM_HOME
 export BOOST_ROOT=$MEM_HOME
-git clone https://github.com/gefei-qian-nih/MemSurfer.git
+conda activate $MEM_HOME
+git clone --recursive https://github.com/gefei-qian-nih/MemSurfer.git
 cd MemSurfer
 CC=`which gcc` CXX=`which g++` LDCXXSHARED="`which g++` -bundle -undefined dynamic_lookup"   python -m pip  install .
 ```

--- a/setup.py
+++ b/setup.py
@@ -165,7 +165,7 @@ if __name__ == '__main__':
     LIBS_EXT = [os.path.basename(l) for l in LIBS_EXT]
     LIBS_EXT = [os.path.splitext(l)[0] for l in LIBS_EXT]
     LIBS_EXT = [l[3:] for l in LIBS_EXT]
-
+    LIBS_EXT = ['CGAL','gmp']
     # --------------------------------------------------------------------------
     # install pypoisson as an Extension module
     # included the setup functionality of https://github.com/mmolero/pypoisson

--- a/setup.py
+++ b/setup.py
@@ -119,7 +119,7 @@ class CustomBuildExt(build_ext):
 
     def build_extensions(self):
         compiler_name = self.compiler.compiler[0]
-        if not self.compiler._is_gcc(compiler_name):
+        if not self.compiler._is_gcc():
             raise Exception(f'Need a GCC compiler. Found ({compiler_name})')
         super().build_extensions()
 


### PR DESCRIPTION
There are two places in setup.py that errored out.
One is about checking gcc compiler name. Noe parameter is needed in _is_gcc() call.
The other is on external library definition.  libgmp was missed. This caused "memsurfer/_memsurfer_cmod.so: undefined symbol: __gmpq_add" error.
These two parts are corrected in setup.py.

In the .sub-module defination, an https link is used for anonymous download.

Instruction is provided to install dependencies with conda.